### PR TITLE
Improved Html Structure and a bug fix in JS file

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,32 +9,73 @@
 </head>
 
 <body>
-  <!--    <span class="bounce-it">bounce</span>-->
-  <!-- Alert !! Don't mess up with index.html file elements if you did it will 
-    generate extra space between each element and your index.js won't work the 
-    way you want
-  it to work
-  For Example: 
-    You decide to create space between elements lik
-    before: <div><span></span><span></span></div> and converted it to this
-    after: <div>
-            <span> </span>
-            <span> </span>
-           </div>
-          Doing this will generate space between the span and div elements and with
-          the space index.js will trouble to produce desired result
--->
   
   <div class="container">
     <div class="wrapper" tabindex="0">
-      <div class="wrapper__text-container"><span class="text">h</span><span class="text">e</span><span class="text">l</span><span class="text">l</span></div><div class="wrapper__text-container"><span class="text">s</span><span class="text">p</span><span
-          class="text">e</span><span class="text">l</span></div><div class="wrapper__text-container"><span class="text">s</span><span class="text">p</span><span
-            class="text">o</span><span class="text">o</span><span class="text">n</span></div><div class="wrapper__text-container"><span class="text">f</span><span class="text">o</span><span
-              class="text">o</span><span class="text">d</span></div><div class="wrapper__text-container"><span class="text">h</span><span class="text">o</span><span
-                class="text">u</span><span class="text">s</span><span class="text">e</span></div><div class="wrapper__text-container"><span class="text">c</span><span class="text">o</span><span
-                  class="text">r</span><span class="text">n</span><span class="text">e</span><span class="text">r</span></div><div class="wrapper__text-container"><span class="text">w</span><span class="text">o</span><span
-                    class="text">r</span><span class="text">k</span><span class="text">i</span><span class="text">n</span><span class="text">g</span></div><div class="wrapper__text-container"><span class="text">b</span><span class="text">o</span><span
-                      class="text">x</span><span class="text">e</span><span class="text">r</span></div>
+
+      <div class="wrapper__text-container">
+        <span class="text">h</span>
+        <span class="text">e</span>
+        <span class="text">l</span>
+        <span class="text">l</span>
+      </div>
+
+      <div class="wrapper__text-container">
+        <span class="text">s</span>
+        <span class="text">p</span>
+        <span class="text">e</span>
+        <span class="text">l</span>
+      </div>
+        
+        <div class="wrapper__text-container">
+          <span class="text">s</span>
+          <span class="text">p</span>
+          <span class="text">o</span>
+          <span class="text">o</span>
+          <span class="text">n</span>
+        </div>
+
+          <div class="wrapper__text-container">
+            <span class="text">f</span>
+            <span class="text">o</span>
+            <span class="text">o</span>
+            <span class="text">d</span>
+          </div>
+
+          <div class="wrapper__text-container">
+            <span class="text">h</span>
+            <span class="text">o</span>
+            <span class="text">u</span>
+            <span class="text">s</span>
+            <span class="text">e</span>
+          </div>
+
+          <div class="wrapper__text-container">
+            <span class="text">c</span>
+            <span class="text">o</span>
+            <span class="text">r</span>
+            <span class="text">n</span>
+            <span class="text">e</span>
+            <span class="text">r</span>
+          </div>
+
+          <div class="wrapper__text-container">
+            <span class="text">w</span>
+            <span class="text">o</span>
+            <span class="text">r</span>
+            <span class="text">k</span>
+            <span class="text">i</span>
+            <span class="text">n</span>
+            <span class="text">g</span>
+          </div>
+
+          <div class="wrapper__text-container">
+            <span class="text">b</span>
+            <span class="text">o</span>
+            <span class="text">x</span>
+            <span class="text">e</span>
+            <span class="text">r</span>
+          </div>
       
     </div>
   </div>

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ wrapper.addEventListener("keydown", (event) => {
 
 const updateElement = (index, currentSpan) =>{
   // Update the spanList
-  spanList = textContainerList[index].childNodes;
+  spanList = textContainerList[index].children;
   
   // Update the length variable
   length = spanList.length - 1;


### PR DESCRIPTION
# HTML File Structure Improved & Bug Fix in Js File
Previously span and div tags were close to each other and the code was hard to read, I've provided space and for that purpose I had to change spanList 
> **spanList = textContainerList[currentSpan].childNodes**  :x: 
to 
> **spanList = textContainerList[currentSpan].children**  :heavy_check_mark:

Reason:
`childNodes` return a list of nodes i.e a list that contain text nodes, space nodes etc. So when we make try to create a space betweeen out html tags our `spanList `is like this `[textNode, spaceNode, textNode, spaceNode]` which isn't what we want , because of this our code breaks.

To fix this issue we used `children` method which return a list of html elements only no space nodes.