### PR TITLE
Two cursors on last letter by pressing wrong letter fixed

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,9 +83,29 @@ wrapper.addEventListener("keydown", (event) => {
     return;
   }
   
-  
+  if (spanList[currentSpan].textContent !== event.key && pushWord) {
+
+    removeCursorAndAnimateLetter(spanList[currentSpan], "newCursor");
+    // return so that code does not go to the next if 
+    return;
+  }
+
   if (spanList[currentSpan].textContent !== event.key) {
-    spanList[currentSpan].classList.remove("cursor");
+
+    removeCursorAndAnimateLetter(spanList[currentSpan],"cursor");
+    return;
+  }
+});
+
+const removeCursorAndAnimateLetter = (letterToAnimate, cursor) => {
+/* 
+1: Cursor is dynamic here it can be newCursor or cursor depending up the
+positon of letter you are at 
+2: if letter is green than there is no need to run wrong letter animation 
+*/
+  if (!letterToAnimate.classList.contains("is-correct")) {
+    
+    spanList[currentSpan].classList.remove(cursor);
     spanList[currentSpan].classList.add("shake");
     spanList[currentSpan].classList.add("is-wrong");
 
@@ -93,10 +113,11 @@ wrapper.addEventListener("keydown", (event) => {
     setTimeout(() => {
       spanList[currentSpan].classList.remove("shake");
       spanList[currentSpan].classList.remove("is-wrong");
-      spanList[currentSpan].classList.add("cursor");
-    }, 800);
+      console.log("adding cursor back", cursor)
+      spanList[currentSpan].classList.add(cursor);
+    }, 800)
   }
-});
+}
 
 const updateElement = (index, currentSpan) =>{
   // Update the spanList


### PR DESCRIPTION
### Fixed Issue of Two Cursors on the last letter appearing on pressing the wrong letter.
**What's cause the issue** 
Since we have `2 cursors` one is `cursor(which is one the left of letter)` other one is `newCursor(which is on the right side of the letter)`, the issue caused because our code was updating based on cursor only and there were no checks for newCursor.

That's why when we reach the very last word and press the wrong key it would simply animate it and add the `newCursor` to the last element but when we type the right word the letter gets green now when we again press any key other than `space bar ( which is there to pop off the word)` our very last letter would animate again too and add `cursor(the one on the left of the letter)` back to the last letter this PR resolves these issues

Additional Changes 👍 
Refactored code by adding new method `removeCursorAndAnimateLetter()` which removes the duplicate code in the following `IF statements`

```
if (spanList[currentSpan].textContent !== event.key && pushWord) {

    removeCursorAndAnimateLetter(spanList[currentSpan], "newCursor");
    // return so that code does not go to the next if 
    return;
  }
```

 ```
 if (spanList[currentSpan].textContent !== event.key) {

    removeCursorAndAnimateLetter(spanList[currentSpan],"cursor");
    return;
  }
```